### PR TITLE
:bug: Fix x-ace-editor.vue readonly not work

### DIFF
--- a/src/components/x-ace-editor.vue/index.js
+++ b/src/components/x-ace-editor.vue/index.js
@@ -43,8 +43,9 @@ export const XAceEditor = {
     },
     mounted() {
         this.editor = ace.edit(this.$el);
-        if (this.options)
-            this.editor.setOptions(this.options);
+        const options = this.options;
+        if (options)
+            this.editor.setOptions(options);
 
         if (this.autofocus)
             this.focusLastLine();
@@ -52,8 +53,8 @@ export const XAceEditor = {
         this.watchLang(this.lang);
         this.watchTheme(this.theme);
         this.watchValue(this.value);
-        this.watchReadonly(this.readonly);
         this.watchDisabled(this.disabled);
+        this.watchReadonly(this.disabled || (options && options.readOnly) || this.readonly);
 
         // @question
         this.editor.$blockScrolling = Infinity;


### PR DESCRIPTION
`ace` 初始化时 `readonly` 最多会经过三次赋值。

+ 引用组件的时候，写在属性上（组件提供的`props`）
+ `options` 中设置 `readOnly ` 属性（`ace`提供的 `options`）
+ 调用 `watchDisabled` 方法会设置  `readOnly ` 属性（组件内部方法调用）

按照目前逻辑，即使按照 方法1 设置了 `true`，但是由于后续调用 `watchDisabled ` ，依然会置为 `false`，最终会导致设置无效。
